### PR TITLE
Add Hire Me page

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -15,7 +15,7 @@ const config = defineConfig({
     socialLinks: [
       {
         icon: "discord",
-        link: "https://discordapp.com/users/310798899738574849",
+        link: "https://discord.com/users/310798899738574849",
       },
       { icon: "x", link: "https://x.com/viell88" },
       { icon: "github", link: "https://github.com/viell-dev" },

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -11,6 +11,7 @@ const config = defineConfig({
   appearance: "force-dark",
   themeConfig: {
     siteTitle: "viell.dev",
+    nav: [{ text: "Hire Me", link: "/hire-me" }],
     socialLinks: [
       {
         icon: "discord",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit",
     "source.fixAll": "explicit"
-  }
+  },
+  "cSpell.words": ["foodstore", "frontends", "viell"]
 }

--- a/src/hire-me.md
+++ b/src/hire-me.md
@@ -1,0 +1,78 @@
+---
+title: Hire Me
+---
+
+# Hire Me
+
+Software architect available for flexible, task-based work. Years of experience wearing multiple hats at small businesses have made me a one-person development and operations team.
+
+## What I Do
+
+Through my work at small businesses, I've developed a broad skill set spanning the full stack and beyond:
+
+- **Full-stack development** — from frontend interfaces to backend services
+- **Server administration** — setup, maintenance, and troubleshooting
+- **System architecture** — designing solutions that scale with your needs
+- **DevOps** — CI/CD pipelines, deployment automation
+- **Manual QA** — hands-on testing to find edge cases and break things before users do
+- **Code review** — PR reviews, catching issues early, knowledge sharing
+
+I'm comfortable jumping into unfamiliar codebases, diagnosing issues, and delivering working solutions.
+
+## Technical Skills
+
+### Languages
+
+- **TypeScript** — my daily driver, haven't written plain JS in years
+- **Rust** — current focus alongside TS
+
+#### Previous experience
+
+C#, PHP (Zend Framework 2/3), Ruby
+
+### Focus Areas
+
+- **Web development** — years of experience in both frontend and backend
+- **Vue.js** — primary frontend framework
+- **Functional TypeScript** — extensive fp-ts experience, currently using Effect
+- I build whatever's needed: CLIs, APIs, frontends
+
+### Infrastructure & Tools
+
+- **Azure**, self-hosted servers, VPS environments
+- **CI/CD pipelines** (GitHub Actions, etc.)
+- **Vagrant** for local development environments
+- **PostgreSQL**, **MySQL/MariaDB**
+
+### Industry Experience
+
+- **B2B SaaS** — cloud booking platforms for interpretation services (multi-party scheduling, billing, communication)
+- **E-commerce** — online foodstore systems
+
+Comfortable with multi-stakeholder platforms where providers, customers, and service workers all interact through one system.
+
+## Availability
+
+I have a full-time position, so I'm looking for **flexible, async-friendly arrangements**:
+
+- **Issue-based work** — Pick up GitHub issues, fix bugs, implement features
+- **Project contributions** — Part-time involvement on specific projects
+- **Consulting** — Architecture reviews, code audits, technical guidance
+
+### Working Style
+
+- Based in **Central European Time (CET)**
+- Async communication preferred
+- **Bounty-style payments** — pay per deliverable, not hours on the clock
+- No retainers or ongoing commitments required
+
+## Let's Talk
+
+Have a project or issue backlog that needs attention? Reach out:
+
+- **Email**: [me@viell.dev](mailto:me@viell.dev)
+- **GitHub**: [viell-dev](https://github.com/viell-dev)
+- **Discord**: [viell-dev](https://discordapp.com/users/310798899738574849)
+- **X**: [@viell88](https://x.com/viell88)
+
+<small>Last updated: February 2026</small>

--- a/src/hire-me.md
+++ b/src/hire-me.md
@@ -72,7 +72,7 @@ Have a project or issue backlog that needs attention? Reach out:
 
 - **Email**: [me@viell.dev](mailto:me@viell.dev)
 - **GitHub**: [viell-dev](https://github.com/viell-dev)
-- **Discord**: [viell-dev](https://discordapp.com/users/310798899738574849)
+- **Discord**: [viell-dev](https://discord.com/users/310798899738574849)
 - **X**: [@viell88](https://x.com/viell88)
 
 <small>Last updated: February 2026</small>


### PR DESCRIPTION
## Summary
- Adds a new "Hire Me" page outlining freelance availability for task-based/bounty-style work
- Includes skills overview, technical experience, working style preferences, and contact info
- Adds navigation link to the header

## Test plan
- [x] Verify page renders correctly at `/hire-me`
- [x] Check navigation link works from any page
- [x] Confirm all contact links are functional

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Hire Me" navigation link to the site.

* **Documentation**
  * Added a new hiring/services page outlining professional capabilities, expertise, engagement options, and contact details.

* **Bug Fixes**
  * Updated the Discord social link to use the correct domain.

* **Chores**
  * Extended local spell-check word list with additional project-specific terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->