### PR TITLE
Add robots.txt to block bots except major search engines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,12 @@
     "source.organizeImports": "explicit",
     "source.fixAll": "explicit"
   },
-  "cSpell.words": ["foodstore", "frontends", "viell"]
+  "cSpell.words": ["foodstore", "frontends", "viell"],
+  "cSpell.ignoreWords": [
+    "Baiduspider",
+    "Bingbot",
+    "Googlebot",
+    "Kagi",
+    "Qwantbot"
+  ]
 }

--- a/src/public/robots.txt
+++ b/src/public/robots.txt
@@ -1,0 +1,33 @@
+# Disallow all bots by default
+User-agent: *
+Disallow: /
+
+# Allow major search engines
+User-agent: Baiduspider
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: KagiBot
+Allow: /
+
+User-agent: Qwantbot
+Allow: /
+
+# Yahoo
+User-agent: Slurp
+Allow: /
+
+User-agent: YandexBot
+Allow: /
+
+# Naver
+User-agent: Yeti
+Allow: /


### PR DESCRIPTION
## Summary
- Adds robots.txt that disallows all bots by default
- Explicitly allows major search engines: Baiduspider, Bingbot, DuckDuckBot, Googlebot, KagiBot, Qwantbot, Slurp (Yahoo), YandexBot, and Yeti (Naver)
- Prevents random bots from hammering the custom domain while still allowing legitimate search indexing

## Test plan
- [ ] Verify robots.txt is accessible at `/robots.txt` after deploy
- [ ] ~Confirm allowed bots can still index the site (check Google Search Console after merge)~

🤖 Generated with [Claude Code](https://claude.ai/code)